### PR TITLE
Fix bash script in QEMU platform

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ start_time=$(date +%s)
 
 # Always use bash
 shell=$(basename $(readlink /proc/$$/exe))
-if [ ! x$shell = x"bash" ]
+if [ ! x$shell = x"bash" ] && [[ x$shell != x"qemu-aarch64"* ]]
 then
     bash $0 $@
     exit $?

--- a/install-third-party.sh
+++ b/install-third-party.sh
@@ -14,7 +14,7 @@
 
 # Always use bash
 shell=$(basename $(readlink /proc/$$/exe))
-if [ ! x$shell = x"bash" ]
+if [ ! x$shell = x"bash" ] && [[ x$shell != x"qemu-aarch64"* ]]
 then
     bash $0 $@
     exit $?


### PR DESCRIPTION
when use QEMU to build ARM docker image for nebula, this check will fail.