### PR TITLE
Fix URL and MD5 mismatch

### DIFF
--- a/project/externals/cyrus-sasl.cmake
+++ b/project/externals/cyrus-sasl.cmake
@@ -7,7 +7,7 @@ set(name cyrus-sasl)
 set(source_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/source)
 ExternalProject_Add(
     ${name}
-    URL https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.27/cyrus-sasl-2.1.27.tar.gz
+    URL https://github.com/cyrusimap/cyrus-sasl/archive/refs/tags/cyrus-sasl-2.1.27.tar.gz
     URL_HASH MD5=271b299bf4059f8ec99c63fa43a0d1a7
     DOWNLOAD_NAME cyrus-sasl-2.1.27.tar.gz
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}


### PR DESCRIPTION
The current MD5 is for https://github.com/cyrusimap/cyrus-sasl/archive/refs/tags/cyrus-sasl-2.1.27.tar.gz.

The current URL does not contain the `autogen.sh` either.

So replace it with the url above.