### PR TITLE
Fix env reference path

### DIFF
--- a/project/externals/config_guess.sh
+++ b/project/externals/config_guess.sh
@@ -1,3 +1,3 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 sh -c "$(curl -fsSL 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD')"


### PR DESCRIPTION
The env path in most systems is /usr/bin/env, and using /bin/env may cause problems that cannot be run