### PR TITLE
add xsimd library

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@
  * wangle
  * zlib
  * zstd
+ * robin-hood-hashing
+ * libev
  * xsimd
 
 # How to Build

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
  * wangle
  * zlib
  * zstd
+ * xsimd
 
 # How to Build
 

--- a/project/CMakeLists.txt
+++ b/project/CMakeLists.txt
@@ -180,6 +180,7 @@ set(ALL_TARGETS
     zstd
     robin-hood-hashing
     libev
+    xsimd
 )
 
 if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64")

--- a/project/externals/xsimd.cmake
+++ b/project/externals/xsimd.cmake
@@ -1,0 +1,30 @@
+# Copyright (c) 2019 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+
+set(name xsimd)
+set(source_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/source)
+ExternalProject_Add(
+    ${name}
+    URL https://github.com/xtensor-stack/xsimd/archive/refs/tags/8.1.0.tar.gz
+    URL_HASH MD5=e3edf90fcdf1d11297ed74bda96d7fbd
+    DOWNLOAD_NAME xsimd-8.1.0.tar.gz
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}
+    TMP_DIR ${BUILD_INFO_DIR}
+    STAMP_DIR ${BUILD_INFO_DIR}
+    DOWNLOAD_DIR ${DOWNLOAD_DIR}
+    SOURCE_DIR ${source_dir}
+    CMAKE_ARGS ${common_cmake_args}
+    BUILD_IN_SOURCE 1
+)
+
+ExternalProject_Add_Step(${name} clean
+    EXCLUDE_FROM_MAIN TRUE
+    ALWAYS TRUE
+    DEPENDEES configure
+    COMMAND make clean -j
+    COMMAND rm -f ${BUILD_INFO_DIR}/${name}-build
+    WORKING_DIRECTORY ${source_dir}
+)
+
+ExternalProject_Add_StepTargets(${name} clean)


### PR DESCRIPTION
- Xsimd (https://github.com/xtensor-stack/xsimd) is C++ wrappers for SIMD intrinsics and parallelized, optimized mathematical functions (SSE, AVX, NEON, AVX512) ;
- Expect to include it to ease implementing some SIMD capability for the runtime/physical operator;
- Adoptions: Apache Arrow, facebook Velox adopted xsimd, so I think it is trustable;