### PR TITLE
fix curl

### DIFF
--- a/project/CMakeLists.txt
+++ b/project/CMakeLists.txt
@@ -261,7 +261,7 @@ maybe_add_dependencies(boost zlib bzip2 lzma)
 maybe_add_dependencies(mstch boost)
 
 maybe_add_dependencies(glog gflags)
-
+maybe_add_dependencies(libcurl openssl)
 maybe_add_dependencies(googlebenchmark googletest)
 
 maybe_add_dependencies(s2geometry googletest glog openssl)

--- a/project/externals/libcurl.cmake
+++ b/project/externals/libcurl.cmake
@@ -13,11 +13,11 @@ ExternalProject_Add(
     TMP_DIR ${BUILD_INFO_DIR}
     STAMP_DIR ${BUILD_INFO_DIR}
     DOWNLOAD_DIR ${DOWNLOAD_DIR}
-    SOURCE_DIR ${source_dir}a
+    SOURCE_DIR ${source_dir}
     CMAKE_ARGS
         ${common_cmake_args}
         -DCMAKE_BUILD_TYPE=Release
-        -DBUILD_CURL_EXE=OFF
+        -D_OPENSSL_LIBDIR=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
     BUILD_IN_SOURCE 1
     BUILD_COMMAND make -s -j${BUILDING_JOBS_NUM}
     INSTALL_COMMAND make -s -j${BUILDING_JOBS_NUM} install


### PR DESCRIPTION
Because the current nebula ent repo uses release 3.3, not master, it needs to be merged into release 3.3.
It is convenient for nebula ent to support rocksdb cloud