### PR TITLE
add http support to thrift

### DIFF
--- a/project/patches/fbthrift-2021-11-29.patch
+++ b/project/patches/fbthrift-2021-11-29.patch
@@ -22,3 +22,27 @@ diff -ur a/thrift/lib/cpp2/server/IOWorkerContext.h b/thrift/lib/cpp2/server/IOW
            }
          });
    }
+diff -ur a/thrift/lib/cpp2/CMakeLists.txt b/thrift/lib/cpp2/server/CMakeLists.txt
+--- a/thrift/lib/cpp2/CMakeLists.txt	2021-11-29 14:14:12.000000000 +0800
++++ b/thrift/lib/cpp2/CMakeLists.txt	2023-01-16 13:14:09.000000000 -0800
+@@ -159,6 +159,7 @@
+   async/HeaderClientChannel.cpp
+   async/HeaderServerChannel.cpp
+   async/HibernatingRequestChannel.cpp
++  async/HTTPClientChannel.cpp
+   async/Interaction.cpp
+   async/MultiplexAsyncProcessor.cpp
+   async/PooledRequestChannel.cpp
+@@ -198,6 +199,12 @@
+   transport/core/ThriftClient.cpp
+   transport/core/ThriftClientCallback.cpp
+   transport/core/ThriftRequest.cpp
++  transport/http2/client/H2ClientConnection.cpp
++  transport/http2/client/ThriftTransactionHandler.cpp
++  transport/http2/common/H2Channel.cpp
++  transport/http2/common/HTTP2RoutingHandler.cpp
++  transport/http2/common/SingleRpcChannel.cpp
++  transport/http2/server/ThriftRequestHandler.cpp
+   transport/rocket/PayloadUtils.cpp
+   transport/rocket/Types.cpp
+   transport/rocket/client/RequestContext.cpp


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [x] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
As part of the solution to https://github.com/vesoft-inc/nebula-ent/issues/2266, we are going to add http support to `fbthrift` first. `Fbthrift` does have http support, but does not include them in default compilation list. In this PR, we add those cpp files into `fbthriftcpp2.a`.

#### Description:


## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


