### PR TITLE
Add dependence of proxygen to fbthrift

### DIFF
--- a/project/CMakeLists.txt
+++ b/project/CMakeLists.txt
@@ -288,7 +288,7 @@ maybe_add_dependencies(krb5 keyutils openssl gettext bison)
 maybe_add_dependencies(folly glog boost double-conversion openssl libevent lzma zstd snappy lz4 libunwind libaio fmt sodium)
 maybe_add_dependencies(fizz folly)
 maybe_add_dependencies(wangle folly fizz)
-maybe_add_dependencies(fbthrift folly krb5 bison flex mstch zlib zstd wangle fatal)
+maybe_add_dependencies(fbthrift folly krb5 bison flex mstch zlib zstd proxygen wangle fatal)
 maybe_add_dependencies(proxygen wangle libunwind gperf)
 
 if(ENABLE_ROCKSDB_CLOUD)


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:
With the HTTP support to thrift, proxygen is required to build fbthrift.

## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


