### PR TITLE
Fix bug of building librdkafka without flag on

### DIFF
--- a/project/CMakeLists.txt
+++ b/project/CMakeLists.txt
@@ -194,7 +194,6 @@ set(ALL_TARGETS
     robin-hood-hashing
     libev
     xsimd
-    librdkafka
 )
 
 if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64")
@@ -235,6 +234,7 @@ endif()
 
 if(ENABLE_ROCKSDB_CLOUD)
     list(APPEND ALL_TARGETS aws-sdk-cpp)
+    list(APPEND ALL_TARGETS librdkafka)
 endif()
 
 foreach(target ${ALL_TARGETS})


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
`librdkafka` depends on `librdkafka berkeleydb libcurl libtool openssl cyrus-sasl`, which is specified under the branch of `if(ENABLE_ROCKSDB_CLOUD)`. However, the `ALL_TARGETS` list now includes `librdkafka` without any condition. That means `librdkafka` will be built without dependency specified. In this PR, I just add `librdkafka` to `ALL_TARGETS` with the condition of `if(ENABLE_ROCKSDB_CLOUD)`.

#### Description:


## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


