### PR TITLE
Build rocksdb cloud together with rocksdb

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,7 +66,7 @@ function check_cxx {
 check_cxx
 
 # Directories setup
-version=3.3
+version=3.4-cloud
 cur_dir=`pwd`
 source_dir=$this_dir/project
 build_root=$cur_dir

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -3,7 +3,7 @@
 this_dir=$(dirname $(readlink -f $0))
 build_root=$(pwd)
 package_dir=$build_root/packages
-version=3.3
+version=3.4-cloud
 
 function atexit() {
     compgen -G $package_dir/vesoft-third-party-*.sh &> /dev/null

--- a/install-third-party.sh
+++ b/install-third-party.sh
@@ -19,7 +19,7 @@ then
     exit $?
 fi
 
-[[ -z $version ]] && version=3.3
+[[ -z $version ]] && version=3.4-cloud
 url_base=https://oss-cdn.nebula-graph.com.cn/third-party/$version
 this_dir=$(dirname $(readlink -f $0))
 cxx_cmd=${CXX:-g++}

--- a/project/CMakeLists.txt
+++ b/project/CMakeLists.txt
@@ -1,10 +1,6 @@
 # The build can be controlled by defining following variables on the
 # <cmake> command line
 #
-# ENABLE_ROCKSDB_CLOUD      -- When true, use the rocksdb cloud version,
-#                           -- when false, use the normal rocksdb version. Default is false.
-
-option(ENABLE_ROCKSDB_CLOUD "Enable rocksdb cloud" OFF)
 
 cmake_minimum_required(VERSION 3.14.0)
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.19")
@@ -183,6 +179,8 @@ set(ALL_TARGETS
     openssl
     proxygen
     rocksdb
+    rocksdb-cloud
+    aws-sdk-cpp
     s2geometry
     simdjson
     snappy
@@ -230,11 +228,6 @@ endif()
 find_package(Gettext QUIET)
 if (NOT Gettext_FOUND)
     list(APPEND ALL_TARGETS gettext)
-endif()
-
-if(ENABLE_ROCKSDB_CLOUD)
-    list(APPEND ALL_TARGETS aws-sdk-cpp)
-    list(APPEND ALL_TARGETS librdkafka)
 endif()
 
 foreach(target ${ALL_TARGETS})
@@ -291,14 +284,11 @@ maybe_add_dependencies(wangle folly fizz)
 maybe_add_dependencies(fbthrift folly krb5 bison flex mstch zlib zstd proxygen wangle fatal)
 maybe_add_dependencies(proxygen wangle libunwind gperf)
 
-if(ENABLE_ROCKSDB_CLOUD)
-    message(STATUS "ENABLE_ROCKSDB_CLOUD is ${ENABLE_ROCKSDB_CLOUD}")
-    maybe_add_dependencies(librdkafka berkeleydb libcurl libtool openssl cyrus-sasl)
-    maybe_add_dependencies(aws-sdk-cpp libcurl openssl zlib)
-    maybe_add_dependencies(rocksdb aws-sdk-cpp librdkafka snappy zlib zstd bzip2 lz4 lzma libunwind)
-else()
-    maybe_add_dependencies(rocksdb snappy zlib zstd bzip2 lz4 lzma libunwind)
-endif()
+
+maybe_add_dependencies(librdkafka berkeleydb libcurl libtool openssl cyrus-sasl)
+maybe_add_dependencies(aws-sdk-cpp libcurl openssl zlib)
+maybe_add_dependencies(rocksdb-cloud aws-sdk-cpp librdkafka snappy zlib zstd bzip2 lz4 lzma libunwind)
+maybe_add_dependencies(rocksdb snappy zlib zstd bzip2 lz4 lzma libunwind)
 
 maybe_add_dependencies(cachelib fbthrift sparsemap fizz googletest)
 

--- a/project/CMakeLists.txt
+++ b/project/CMakeLists.txt
@@ -192,6 +192,7 @@ set(ALL_TARGETS
     robin-hood-hashing
     libev
     xsimd
+    librdkafka
 )
 
 if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64")

--- a/project/externals/aws-sdk-cpp.cmake
+++ b/project/externals/aws-sdk-cpp.cmake
@@ -2,8 +2,6 @@
 #
 # This source code is licensed under Apache 2.0 License.
 
-#set(AWS_BUILD "\\\"s3;kinesis;transfer\\\"")
-
 set(name aws-sdk-cpp)
 set(source_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/source)
 

--- a/project/externals/aws-sdk-cpp.cmake
+++ b/project/externals/aws-sdk-cpp.cmake
@@ -2,6 +2,8 @@
 #
 # This source code is licensed under Apache 2.0 License.
 
+#set(AWS_BUILD "\\\"s3;kinesis;transfer\\\"")
+
 if(ENABLE_ROCKSDB_CLOUD)
     message(STATUS "use rocksdb cloud")
     set(name aws-sdk-cpp)
@@ -18,12 +20,14 @@ if(ENABLE_ROCKSDB_CLOUD)
         STAMP_DIR ${BUILD_INFO_DIR}
         DOWNLOAD_DIR ${DOWNLOAD_DIR}
         #PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/patches/${name}-2022-9-19.patch
-        SOURCE_DIR ${source_dir}
-        CMAKE_ARGS
+	SOURCE_DIR ${source_dir}
+	LIST_SEPARATOR "|"
+	CMAKE_ARGS
             ${common_cmake_args}
             -DENABLE_TESTING=OFF
             -DBUILD_SHARED_LIBS=OFF
             -DCMAKE_BUILD_TYPE=Release
+	    -DBUILD_ONLY=s3|kinesis|transfer
         BUILD_COMMAND make -s -j${BUILDING_JOBS_NUM}
         BUILD_IN_SOURCE 1
         INSTALL_COMMAND make -s -j${BUILDING_JOBS_NUM} install

--- a/project/externals/aws-sdk-cpp.cmake
+++ b/project/externals/aws-sdk-cpp.cmake
@@ -4,46 +4,43 @@
 
 #set(AWS_BUILD "\\\"s3;kinesis;transfer\\\"")
 
-if(ENABLE_ROCKSDB_CLOUD)
-    message(STATUS "use rocksdb cloud")
-    set(name aws-sdk-cpp)
-    set(source_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/source)
+set(name aws-sdk-cpp)
+set(source_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/source)
 
-    ExternalProject_Add_Git(
-        ${name}
-        GIT_REPOSITORY https://github.com/aws/aws-sdk-cpp.git
-        GIT_TAG f61fa33a65d4c37cc3f2069d558771b45196158c  # As of 2022/9/19
-        #ARCHIVE_FILE aws-sdk-2022-9-19.tar.gz
-        #ARCHIVE_MD5 bee5b1a24318547232be73dbf06dbcc3
-        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}
-        TMP_DIR ${BUILD_INFO_DIR}
-        STAMP_DIR ${BUILD_INFO_DIR}
-        DOWNLOAD_DIR ${DOWNLOAD_DIR}
-        #PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/patches/${name}-2022-9-19.patch
-	SOURCE_DIR ${source_dir}
-	LIST_SEPARATOR "|"
-	CMAKE_ARGS
-            ${common_cmake_args}
-            -DENABLE_TESTING=OFF
-            -DBUILD_SHARED_LIBS=OFF
-            -DCMAKE_BUILD_TYPE=Release
-	    -DBUILD_ONLY=s3|kinesis|transfer
-        BUILD_COMMAND make -s -j${BUILDING_JOBS_NUM}
-        BUILD_IN_SOURCE 1
-        INSTALL_COMMAND make -s -j${BUILDING_JOBS_NUM} install
-        LOG_CONFIGURE TRUE
-        LOG_BUILD TRUE
-        LOG_INSTALL TRUE
-    )
+ExternalProject_Add_Git(
+    ${name}
+    GIT_REPOSITORY https://github.com/aws/aws-sdk-cpp.git
+    GIT_TAG f61fa33a65d4c37cc3f2069d558771b45196158c  # As of 2022/9/19
+    #ARCHIVE_FILE aws-sdk-2022-9-19.tar.gz
+    #ARCHIVE_MD5 bee5b1a24318547232be73dbf06dbcc3
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}
+    TMP_DIR ${BUILD_INFO_DIR}
+    STAMP_DIR ${BUILD_INFO_DIR}
+    DOWNLOAD_DIR ${DOWNLOAD_DIR}
+    #PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/patches/${name}-2022-9-19.patch
+SOURCE_DIR ${source_dir}
+LIST_SEPARATOR "|"
+CMAKE_ARGS
+        ${common_cmake_args}
+        -DENABLE_TESTING=OFF
+        -DBUILD_SHARED_LIBS=OFF
+        -DCMAKE_BUILD_TYPE=Release
+    -DBUILD_ONLY=s3|kinesis|transfer
+    BUILD_COMMAND make -s -j${BUILDING_JOBS_NUM}
+    BUILD_IN_SOURCE 1
+    INSTALL_COMMAND make -s -j${BUILDING_JOBS_NUM} install
+    LOG_CONFIGURE TRUE
+    LOG_BUILD TRUE
+    LOG_INSTALL TRUE
+)
 
-    ExternalProject_Add_Step(${name} clean
-        EXCLUDE_FROM_MAIN TRUE
-        ALWAYS TRUE
-        DEPENDEES configure
-        COMMAND make clean -j
-        COMMAND rm -f ${BUILD_INFO_DIR}/${name}-build
-        WORKING_DIRECTORY ${source_dir}
-    )
+ExternalProject_Add_Step(${name} clean
+    EXCLUDE_FROM_MAIN TRUE
+    ALWAYS TRUE
+    DEPENDEES configure
+    COMMAND make clean -j
+    COMMAND rm -f ${BUILD_INFO_DIR}/${name}-build
+    WORKING_DIRECTORY ${source_dir}
+)
 
-    ExternalProject_Add_StepTargets(${name} clean)
-endif()
+ExternalProject_Add_StepTargets(${name} clean)

--- a/project/externals/rocksdb-cloud-update-headers.cmake
+++ b/project/externals/rocksdb-cloud-update-headers.cmake
@@ -1,25 +1,17 @@
-# Copyright (c) 2019 vesoft inc. All rights reserved.
+# Copyright (c) 2023 vesoft inc. All rights reserved.
 #
 # This source code is licensed under Apache 2.0 License.
 
-# Update the include in headers to reflect the header folder name change
+# Update the #include in headers to reflect the header folder name change
 set(headers_directory "${INSTALL_PREFIX}/include/rocksdb-cloud")
 
 file(GLOB_RECURSE header_files
     LIST_DIRECTORIES false
     "${headers_directory}/*.h"
 )
-list(LENGTH header_files file_num)
-message(STATUS "headers directory: ${headers_directory}")
-#message(STATUS "header files: ${header_files}")
-message(STATUS "header file num: ${file_num}")
 
-foreach(header_file ${header_files})
-	#    message(STATUS "header file: ${header_file}")
-    
+foreach(header_file ${header_files})    
     file(READ ${header_file} contents)
-
     string(REPLACE "#include \"rocksdb" "#include \"rocksdb-cloud" new_contents "${contents}")
-
     file(WRITE ${header_file} "${new_contents}")
 endforeach()

--- a/project/externals/rocksdb-cloud-update-headers.cmake
+++ b/project/externals/rocksdb-cloud-update-headers.cmake
@@ -3,14 +3,20 @@
 # This source code is licensed under Apache 2.0 License.
 
 # Update the include in headers to reflect the header folder name change
-set(headers_directory "${CMAKE_INSTALL_PREFIX}/include/rocksdb-cloud")
+set(headers_directory "${INSTALL_PREFIX}/include/rocksdb-cloud")
 
 file(GLOB_RECURSE header_files
     LIST_DIRECTORIES false
     "${headers_directory}/*.h"
 )
+list(LENGTH header_files file_num)
+message(STATUS "headers directory: ${headers_directory}")
+#message(STATUS "header files: ${header_files}")
+message(STATUS "header file num: ${file_num}")
 
 foreach(header_file ${header_files})
+	#    message(STATUS "header file: ${header_file}")
+    
     file(READ ${header_file} contents)
 
     string(REPLACE "#include \"rocksdb" "#include \"rocksdb-cloud" new_contents "${contents}")

--- a/project/externals/rocksdb-cloud-update-headers.cmake
+++ b/project/externals/rocksdb-cloud-update-headers.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) 2019 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+
+# Update the include in headers to reflect the header folder name change
+set(headers_directory "${CMAKE_INSTALL_PREFIX}/include/rocksdb-cloud")
+
+file(GLOB_RECURSE header_files
+    LIST_DIRECTORIES false
+    "${headers_directory}/*.h"
+)
+
+foreach(header_file ${header_files})
+    file(READ ${header_file} contents)
+
+    string(REPLACE "#include \"rocksdb" "#include \"rocksdb-cloud" new_contents "${contents}")
+
+    file(WRITE ${header_file} "${new_contents}")
+endforeach()

--- a/project/externals/rocksdb-cloud.cmake
+++ b/project/externals/rocksdb-cloud.cmake
@@ -47,6 +47,18 @@ ExternalProject_Add_Step(${name} install-static
     WORKING_DIRECTORY ${source_dir}
 )
 
+ExternalProject_Add_Step(${name} replace-rocksdb
+    DEPENDEES install-static
+    DEPENDERS install
+    ALWAYS false
+    COMMAND
+        ${CMAKE_COMMAND} -E echo "Replacing #include \"rocksdb to #include \"rocksdb-cloud in header files"
+    COMMAND
+        ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb-cloud-update-headers.cmake
+    WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/include/rocksdb-cloud
+    COMMENT "Replacing #include \"rocksdb to #include \"rocksdb-cloud in header files"
+)
+
 ExternalProject_Add_Step(${name} clean
     EXCLUDE_FROM_MAIN TRUE
     ALWAYS TRUE

--- a/project/externals/rocksdb-cloud.cmake
+++ b/project/externals/rocksdb-cloud.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 vesoft inc. All rights reserved.
+# Copyright (c) 2023 vesoft inc. All rights reserved.
 #
 # This source code is licensed under Apache 2.0 License.
 
@@ -69,4 +69,3 @@ ExternalProject_Add_Step(${name} clean
 )
 
 ExternalProject_Add_StepTargets(${name} clean)
-

--- a/project/externals/rocksdb-cloud.cmake
+++ b/project/externals/rocksdb-cloud.cmake
@@ -21,7 +21,6 @@ ExternalProject_Add(
     TMP_DIR ${BUILD_INFO_DIR}
     STAMP_DIR ${BUILD_INFO_DIR}
     DOWNLOAD_DIR ${DOWNLOAD_DIR}
-    #PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/patches/${name}-2022-9-19.patch
     SOURCE_DIR ${source_dir}
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ""
@@ -43,11 +42,11 @@ ExternalProject_Add_Step(${name} install-static
     COMMAND
         ${CMAKE_COMMAND} -E copy
         ${source_dir}/librocksdb.a
-        ${CMAKE_INSTALL_PREFIX}/lib/librocksdb-cloud.a
+        ${CMAKE_INSTALL_PREFIX}/lib/librocksdb_cloud.a
     WORKING_DIRECTORY ${source_dir}
 )
 
-ExternalProject_Add_Step(${name} replace-rocksdb
+ExternalProject_Add_Step(${name} update-headers
     DEPENDEES install-static
     DEPENDERS install
     ALWAYS false

--- a/project/externals/rocksdb-cloud.cmake
+++ b/project/externals/rocksdb-cloud.cmake
@@ -1,0 +1,60 @@
+# Copyright (c) 2019 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+
+set(name rocksdb-cloud)
+set(source_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/source)
+
+set(MakeEnvs "env" "EXTRA_CXXFLAGS=-I${CMAKE_INSTALL_PREFIX}/include" "USE_AWS=1" "USE_KAFKA=1" "PORTABLE=1" "WITH_SNAPPY=1"
+    "WITH_ZSTD=1" "WITH_ZLIB=1" "WITH_LZ4=1" "WITH_BZ2=1" "WITH_JEMALLOC=0" "WITH_GFLAGS=0" "WITH_TESTS=0"
+    "WITH_BENCHMARK_TOOLS=0" "WITH_TOOLS=0" "USE_RTTI=1" "FAIL_ON_WARNINGS=0" "WITH_AWS=1" "DISABLE_WARNING_AS_ERROR=0")
+
+set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_PREFIX}/include/rocksdb-cloud)
+
+ExternalProject_Add(
+    ${name}
+    GIT_REPOSITORY https://github.com/rockset/rocksdb-cloud.git
+    GIT_TAG 956da0d46623d956670703a4af73b2526a5cd3cb  # As of 2022/9/19
+    #ARCHIVE_FILE rocksdb-2022-9-19.tar.gz
+    #ARCHIVE_MD5 89854dbe4a857068381b572081ab1e19
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}
+    TMP_DIR ${BUILD_INFO_DIR}
+    STAMP_DIR ${BUILD_INFO_DIR}
+    DOWNLOAD_DIR ${DOWNLOAD_DIR}
+    #PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/patches/${name}-2022-9-19.patch
+    SOURCE_DIR ${source_dir}
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND
+        "${MakeEnvs}"
+        make static_lib -j${BUILDING_JOBS_NUM}
+    INSTALL_COMMAND ""
+    LOG_CONFIGURE TRUE
+    LOG_BUILD TRUE
+    LOG_INSTALL TRUE
+)
+
+ExternalProject_Add_Step(${name} install-static
+    DEPENDEES build
+    DEPENDERS install
+    ALWAYS false
+    COMMAND
+        ${CMAKE_COMMAND} -E copy_directory ${source_dir}/include/rocksdb ${CMAKE_INSTALL_PREFIX}/include/rocksdb-cloud
+    COMMAND
+        ${CMAKE_COMMAND} -E copy
+        ${source_dir}/librocksdb.a
+        ${CMAKE_INSTALL_PREFIX}/lib/librocksdb-cloud.a
+    WORKING_DIRECTORY ${source_dir}
+)
+
+ExternalProject_Add_Step(${name} clean
+    EXCLUDE_FROM_MAIN TRUE
+    ALWAYS TRUE
+    DEPENDEES configure
+    COMMAND make clean -j
+    COMMAND rm -f ${BUILD_INFO_DIR}/${name}-build
+    WORKING_DIRECTORY ${source_dir}
+)
+
+ExternalProject_Add_StepTargets(${name} clean)
+

--- a/project/externals/rocksdb-cloud.cmake
+++ b/project/externals/rocksdb-cloud.cmake
@@ -54,7 +54,7 @@ ExternalProject_Add_Step(${name} replace-rocksdb
     COMMAND
         ${CMAKE_COMMAND} -E echo "Replacing #include \"rocksdb to #include \"rocksdb-cloud in header files"
     COMMAND
-        ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb-cloud-update-headers.cmake
+    ${CMAKE_COMMAND} -DINSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -P ${CMAKE_CURRENT_SOURCE_DIR}/externals/rocksdb-cloud-update-headers.cmake
     WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/include/rocksdb-cloud
     COMMENT "Replacing #include \"rocksdb to #include \"rocksdb-cloud in header files"
 )

--- a/project/externals/rocksdb.cmake
+++ b/project/externals/rocksdb.cmake
@@ -5,76 +5,44 @@
 set(name rocksdb)
 set(source_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/source)
 
-set(MakeEnvs "env" "EXTRA_CXXFLAGS=-I${CMAKE_INSTALL_PREFIX}/include" "USE_AWS=1" "USE_KAFKA=1" "PORTABLE=1" "WITH_SNAPPY=1"
-    "WITH_ZSTD=1" "WITH_ZLIB=1" "WITH_LZ4=1" "WITH_BZ2=1" "WITH_JEMALLOC=0" "WITH_GFLAGS=0" "WITH_TESTS=0"
-    "WITH_BENCHMARK_TOOLS=0" "WITH_TOOLS=0" "USE_RTTI=1" "FAIL_ON_WARNINGS=0" "WITH_AWS=1" "DISABLE_WARNING_AS_ERROR=0")
 
-#do not set EXTRA_LDFLAGS
+ExternalProject_Add(
+    ${name}
+    URL https://github.com/facebook/rocksdb/archive/refs/tags/v7.5.3.tar.gz
+    URL_HASH MD5=5195c23691906f557aaa1827291196fd
+    DOWNLOAD_NAME rocksdb-7.5.3.tar.gz
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}
+    TMP_DIR ${BUILD_INFO_DIR}
+    STAMP_DIR ${BUILD_INFO_DIR}
+    DOWNLOAD_DIR ${DOWNLOAD_DIR}
+    SOURCE_DIR ${source_dir}
+    UPDATE_COMMAND ""
+    CMAKE_ARGS
+        ${common_cmake_args}
+        -DPORTABLE=ON
+        -DWITH_SNAPPY=ON
+        -DWITH_ZSTD=ON
+        -DWITH_ZLIB=ON
+        -DWITH_LZ4=ON
+        -DWITH_BZ2=ON
+        -DWITH_JEMALLOC=OFF
+        -DWITH_GFLAGS=OFF
+        -DWITH_TESTS=OFF
+        -DWITH_BENCHMARK_TOOLS=OFF
+        -DWITH_TOOLS=OFF
+        -DUSE_RTTI=ON
+        -DFAIL_ON_WARNINGS=OFF
+        -DCMAKE_BUILD_TYPE=Release
+        "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -D NPERF_CONTEXT"
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND make -s -j${BUILDING_JOBS_NUM}
+    INSTALL_COMMAND ""
+    LOG_CONFIGURE TRUE
+    LOG_BUILD TRUE
+    LOG_INSTALL TRUE
+)
 
-if(ENABLE_ROCKSDB_CLOUD)
-    message(STATUS "use rocksdb cloud")
-    ExternalProject_Add(
-        ${name}
-        GIT_REPOSITORY https://github.com/rockset/rocksdb-cloud.git
-        GIT_TAG 956da0d46623d956670703a4af73b2526a5cd3cb  # As of 2022/9/19
-        #ARCHIVE_FILE rocksdb-2022-9-19.tar.gz
-        #ARCHIVE_MD5 89854dbe4a857068381b572081ab1e19
-        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}
-        TMP_DIR ${BUILD_INFO_DIR}
-        STAMP_DIR ${BUILD_INFO_DIR}
-        DOWNLOAD_DIR ${DOWNLOAD_DIR}
-        #PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/patches/${name}-2022-9-19.patch
-        SOURCE_DIR ${source_dir}
-        BUILD_IN_SOURCE 1
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND
-            "${MakeEnvs}"
-            make static_lib -j${BUILDING_JOBS_NUM}
-        INSTALL_COMMAND
-            make install -j${BUILDING_JOBS_NUM} PREFIX=${CMAKE_INSTALL_PREFIX}
-        LOG_CONFIGURE TRUE
-        LOG_BUILD TRUE
-        LOG_INSTALL TRUE
-    )
-else()
-    message(STATUS "use rocksdb native")
-    ExternalProject_Add(
-        ${name}
-        URL https://github.com/facebook/rocksdb/archive/refs/tags/v7.5.3.tar.gz
-        URL_HASH MD5=5195c23691906f557aaa1827291196fd
-        DOWNLOAD_NAME rocksdb-7.5.3.tar.gz
-        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}
-        TMP_DIR ${BUILD_INFO_DIR}
-        STAMP_DIR ${BUILD_INFO_DIR}
-        DOWNLOAD_DIR ${DOWNLOAD_DIR}
-        SOURCE_DIR ${source_dir}
-        UPDATE_COMMAND ""
-        CMAKE_ARGS
-            ${common_cmake_args}
-            -DPORTABLE=ON
-            -DWITH_SNAPPY=ON
-            -DWITH_ZSTD=ON
-            -DWITH_ZLIB=ON
-            -DWITH_LZ4=ON
-            -DWITH_BZ2=ON
-            -DWITH_JEMALLOC=OFF
-            -DWITH_GFLAGS=OFF
-            -DWITH_TESTS=OFF
-            -DWITH_BENCHMARK_TOOLS=OFF
-            -DWITH_TOOLS=OFF
-            -DUSE_RTTI=ON
-            -DFAIL_ON_WARNINGS=OFF
-            -DCMAKE_BUILD_TYPE=Release
-            "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -D NPERF_CONTEXT"
-        BUILD_IN_SOURCE 1
-        BUILD_COMMAND make -s -j${BUILDING_JOBS_NUM}
-        INSTALL_COMMAND ""
-        LOG_CONFIGURE TRUE
-        LOG_BUILD TRUE
-        LOG_INSTALL TRUE
-    )
-
-   ExternalProject_Add_Step(${name} install-static
+ExternalProject_Add_Step(${name} install-static
     DEPENDEES build
     DEPENDERS install
     ALWAYS false
@@ -84,7 +52,6 @@ else()
         find ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR} -name "librocksdb.so*" -delete
     WORKING_DIRECTORY ${source_dir}
 )
-endif()
 
 ExternalProject_Add_Step(${name} clean
     EXCLUDE_FROM_MAIN TRUE


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [x] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula-ent/issues/2597
https://github.com/vesoft-inc/nebula-ent/issues/1372

#### Description:
Try to build rocksdb-cloud together with rocksdb. So we will have better flexibility on integrating with nebula. To achieve this, we update the header files location from `rocksdb` to `rocksdb-cloud`. We also change the static lib name to `rocksdb_cloud.a`.

In addition, when building aws-sdk-cpp, we only build the essential ones.

## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


