### PR TITLE
Build rocksdb-cloud first

### DIFF
--- a/project/CMakeLists.txt
+++ b/project/CMakeLists.txt
@@ -289,7 +289,7 @@ maybe_add_dependencies(proxygen wangle libunwind gperf)
 maybe_add_dependencies(librdkafka berkeleydb libcurl libtool openssl cyrus-sasl)
 maybe_add_dependencies(aws-sdk-cpp libcurl openssl zlib)
 maybe_add_dependencies(rocksdb-cloud aws-sdk-cpp librdkafka snappy zlib zstd bzip2 lz4 lzma libunwind)
-maybe_add_dependencies(rocksdb snappy zlib zstd bzip2 lz4 lzma libunwind)
+maybe_add_dependencies(rocksdb snappy zlib zstd bzip2 lz4 lzma libunwind rocksdb-cloud)
 
 maybe_add_dependencies(cachelib fbthrift sparsemap fizz googletest)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:

Building rocksdb cloud relies on the headers from those earlier built libraries. "{CMAKE_INSTALL_PREFIX}/include". If rocksdb is built first, it will include the headers from rocksdb, and cause the conflict.

## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


