### PR TITLE
Revert ‘Update workflow’

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
           #- ubuntu1804
           - ubuntu2004
           - ubuntu2204
+          #- ubuntu2304
         compiler:
           - 9.3.0
           - ''
@@ -37,17 +38,17 @@ jobs:
         exclude:
           - os: centos7
             compiler: ''
-          - os: centos8
-            compiler: ''
           - os: ubuntu2204
             compiler: '9.3.0' 
+          - os: ubuntu2304
+            compiler: '9.3.0'
     container:
-      image: reg.vesoft-inc.com/vesoft/third-party-build:${{ matrix.os }}
+      image: vesoft/third-party-build:${{ matrix.os }}
     steps:
-    - uses: webiny/action-post-run@3.1.0
+    - uses: webiny/action-post-run@3.0.0
       with:
         run: sh -c "find . -mindepth 1 -delete"
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Set up environment
       if: matrix.compiler != ''
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
           #- ubuntu1804
           - ubuntu2004
           - ubuntu2204
-          #- ubuntu2304
         compiler:
           - 9.3.0
           - ''

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,6 @@ jobs:
             compiler: ''
           - os: ubuntu2204
             compiler: '9.3.0' 
-          - os: ubuntu2304
-            compiler: '9.3.0'
     container:
       image: reg.vesoft-inc.com/vesoft/third-party-build:${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,17 +38,19 @@ jobs:
         exclude:
           - os: centos7
             compiler: ''
+          - os: centos8
+            compiler: ''
           - os: ubuntu2204
             compiler: '9.3.0' 
           - os: ubuntu2304
             compiler: '9.3.0'
     container:
-      image: vesoft/third-party-build:${{ matrix.os }}
+      image: reg.vesoft-inc.com/vesoft/third-party-build:${{ matrix.os }}
     steps:
     - uses: webiny/action-post-run@3.0.0
       with:
         run: sh -c "find . -mindepth 1 -delete"
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up environment
       if: matrix.compiler != ''
       run: |


### PR DESCRIPTION
Reverts vesoft-inc/nebula-third-party#126

Just revert action ‘webiny/action-post-run’，because of centos7 don't support node20 binary