### PR TITLE
Do not build jemalloc in DuckDB due to 64K pagesize in aarch64

### DIFF
--- a/project/externals/duckdb.cmake
+++ b/project/externals/duckdb.cmake
@@ -18,7 +18,7 @@ ExternalProject_Add(
     DOWNLOAD_DIR ${DOWNLOAD_DIR}
     SOURCE_DIR ${source_dir}
     PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/patches/${name}-0.6.1.patch
-    CONFIGURE_COMMAND ""
+    CONFIGURE_COMMAND sed -i "s/DBUILD_JEMALLOC_EXTENSION=1/DBUILD_JEMALLOC_EXTENSION=0/" ${source_dir}/Makefile
     BUILD_COMMAND
         "${make_envs}"
         make -e -s -j${BUILDING_JOBS_NUM}


### PR DESCRIPTION
DuckDB will throw std::bad_alloc if the page size is 64KB in the aarch64 platform. So we disable the build of jemalloc in the DuckDB build.