### PR TITLE
Fix s2

### DIFF
--- a/project/externals/s2geometry.cmake
+++ b/project/externals/s2geometry.cmake
@@ -6,18 +6,19 @@ set(name s2geometry)
 set(source_dir ${CMAKE_CURRENT_BINARY_DIR}/${name}/source)
 ExternalProject_Add(
     ${name}
-    URL  https://github.com/google/s2geometry/archive/v0.10.0.tar.gz
-    URL_HASH MD5=c68f3c5d326dde9255681b9201393a9f
-    DOWNLOAD_NAME ${name}-0.10.0.tar.gz
+    URL  https://github.com/google/s2geometry/archive/v0.9.0.tar.gz
+    URL_HASH MD5=293552c7646193b8b4a01556808fe155
+    DOWNLOAD_NAME ${name}-0.9.0.tar.gz
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/${name}
     TMP_DIR ${BUILD_INFO_DIR}
     STAMP_DIR ${BUILD_INFO_DIR}
     DOWNLOAD_DIR ${DOWNLOAD_DIR}
     SOURCE_DIR ${source_dir}
-    PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/patches/${name}-0.10.0.patch
+    PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/patches/${name}-0.9.0.patch
     CMAKE_ARGS
         ${common_cmake_args}
         -DCMAKE_BUILD_TYPE=Release
+        -DS2_USE_GLOG=ON
         -DBUILD_EXAMPLES=OFF
         -DWITH_GLOG=ON
         -DWITH_GFLAGS=ON

--- a/project/patches/s2geometry-0.9.0.patch
+++ b/project/patches/s2geometry-0.9.0.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5ecd280..582b6e3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -13,7 +13,7 @@ if (APPLE)
+     set(CMAKE_MACOSX_RPATH TRUE)
+ endif()
+ 
+-set(CMAKE_CXX_STANDARD 11)
++set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ # No compiler-specific extensions, i.e. -std=c++11, not -std=gnu++11.
+ set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

This pr fix s2 build by downgraph s2 from version v0.10.0 to v0.9.0 to avoid ut(with ASAN enabled) crash when linking to s2. This is an annoying problem introduced since s2 v0.10.0 which depends on absl. When an ut using s2 and compiled with asan enabled, s2 will crash in the process of initializing some absl container or strange absl seg faults.

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:


## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


